### PR TITLE
Bump L.EventBus.RabbitMQ version to 2.1.0

### DIFF
--- a/src/L.EventBus.RabbitMQ/L.EventBus.RabbitMQ.csproj
+++ b/src/L.EventBus.RabbitMQ/L.EventBus.RabbitMQ.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <Version>2.0.0</Version>
+	  <Version>2.1.0</Version>
 	  <RepositoryUrl>https://github.com/Liveron/L.EventBus</RepositoryUrl>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Bump L.EventBus.RabbitMQ version from 2.0.0 to 2.1.0
- Minor version increment for new generic serializer features added in previous commit
- Includes generic typed context and filter interfaces
- Adds open generic type registration support