### PR TITLE
Fix hosted service registration to use IRabbitMqEventBus interface

### DIFF
--- a/src/L.EventBus.RabbitMQ/DependencyInjection/Configuration/DiEventBusConfiguratorExtensions.cs
+++ b/src/L.EventBus.RabbitMQ/DependencyInjection/Configuration/DiEventBusConfiguratorExtensions.cs
@@ -26,7 +26,7 @@ public static class DiEventBusConfiguratorExtensions
         eventBusConfigurator.Services.AddSingleton(connection);
 
         eventBusConfigurator.Services.AddSingleton<IRabbitMqEventBus, RabbitMqEventBus>();
-        eventBusConfigurator.Services.AddHostedService(sp => (RabbitMqEventBus)sp.GetRequiredService<IEventBus>());
+        eventBusConfigurator.Services.AddHostedService(sp => sp.GetRequiredService<IRabbitMqEventBus>());
     }
 
     private static void AddDefaultFilters(this IServiceCollection services)


### PR DESCRIPTION
## Summary
- Fixed hosted service registration to use specific IRabbitMqEventBus interface instead of generic IEventBus

This change improves type safety by using the more specific interface type when registering the RabbitMQ event bus as a hosted service.