### PR TITLE
Implement RabbitMqFiltersResolver and enhance context management

### DIFF
--- a/src/L.EventBus.RabbitMQ/Context/RabbitMqConsumeContext.cs
+++ b/src/L.EventBus.RabbitMQ/Context/RabbitMqConsumeContext.cs
@@ -5,7 +5,8 @@ namespace L.EventBus.RabbitMQ.Context;
 
 public class RabbitMqConsumeContext(object payload, ulong deliveryTag) : IPipeContext
 {
-    public IDictionary<string, object?> Headers { get; init; } = new Dictionary<string, object?>();
+    public Dictionary<string, object?> Headers { get; init; } = [];
+    public Dictionary<string, object?> Items { get; init; } = [];
     public object Payload { get; set; } = payload;
     public ulong DeliveryTag { get; set; } = deliveryTag;
     public string EventName

--- a/src/L.EventBus.RabbitMQ/DependencyInjection/Configuration/DiEventBusConfiguratorExtensions.cs
+++ b/src/L.EventBus.RabbitMQ/DependencyInjection/Configuration/DiEventBusConfiguratorExtensions.cs
@@ -26,7 +26,7 @@ public static class DiEventBusConfiguratorExtensions
         eventBusConfigurator.Services.AddSingleton(connection);
 
         eventBusConfigurator.Services.AddSingleton<IRabbitMqEventBus, RabbitMqEventBus>();
-        eventBusConfigurator.Services.AddHostedService(sp => (RabbitMqEventBus)sp.GetRequiredService<IEventBus>());
+        eventBusConfigurator.Services.AddHostedService(sp => sp.GetRequiredService<IRabbitMqEventBus>());
     }
 
     private static void AddDefaultFilters(this IServiceCollection services)

--- a/src/L.EventBus.RabbitMQ/Filters/Resolver/RabbitMqFiltersResolver.cs
+++ b/src/L.EventBus.RabbitMQ/Filters/Resolver/RabbitMqFiltersResolver.cs
@@ -1,11 +1,19 @@
-﻿using L.Pipes.Abstractions;
+﻿using L.EventBus.RabbitMQ.Filters.MessagePublishing;
+using L.EventBus.RabbitMQ.Filters.Serialization;
+using L.Pipes.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace L.EventBus.RabbitMQ.Filters.Resolver;
 
-//public class RabbitMqFiltersResolver
-//{
-//    public IEnumerable<IFilter> GetFilters<TMessage>(TMessage message, IServiceProvider provider)
-//    {
-//        var filters = pr
-//    }
-//}
+public class RabbitMqFiltersResolver
+{
+    public IEnumerable<IFilter> GetPublishFilters<TMessage>(IServiceProvider provider) where TMessage : notnull
+    {
+        var filters = provider.GetServices<IRabbitMqPublishFilter>();
+        IRabbitMqMessageSerializerFilter? serializer;
+        serializer = provider.GetService<IRabbitMqMessageSerializerFilter<TMessage>>();
+        serializer ??= provider.GetRequiredService<IRabbitMqMessageSerializerFilter>();
+        var publisher = provider.GetRequiredService<IRabbitMqMessagePublisherFilter>();
+        return [.. filters, serializer, publisher];
+    }
+}

--- a/src/L.EventBus.RabbitMQ/L.EventBus.RabbitMQ.csproj
+++ b/src/L.EventBus.RabbitMQ/L.EventBus.RabbitMQ.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <Version>2.1.0</Version>
+	  <Version>2.1.1</Version>
 	  <RepositoryUrl>https://github.com/Liveron/L.EventBus</RepositoryUrl>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Implement `RabbitMqFiltersResolver` with `GetPublishFilters` method for filter pipeline resolution
- Add support for both typed and generic message serializer filters in publishing pipeline
- Enhance `RabbitMqConsumeContext` with `Items` dictionary for filter state sharing
- Modernize `Headers` property to use concrete Dictionary type with collection expression

This enhances the filter architecture by providing a centralized resolver for the publishing pipeline and improves context management for filter state sharing.