### PR TITLE
Bump L.EventBus.RabbitMQ version to 2.2.0 and strengthen version management

### DIFF
--- a/src/L.EventBus.RabbitMQ/L.EventBus.RabbitMQ.csproj
+++ b/src/L.EventBus.RabbitMQ/L.EventBus.RabbitMQ.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <Version>2.1.1</Version>
+	  <Version>2.2.0</Version>
 	  <RepositoryUrl>https://github.com/Liveron/L.EventBus</RepositoryUrl>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Update L.EventBus.RabbitMQ version from 2.1.1 to 2.2.0 for new RabbitMqFiltersResolver functionality
- Enhance CLAUDE.md with mandatory version update requirements to prevent version management oversights
- Make version management guidelines more explicit and enforceable

This addresses the missing version update in the previous commit and strengthens the project guidelines.