### PR TITLE
Fix Headers property type and bump version to 2.2.1

### DIFF
--- a/src/L.EventBus.RabbitMQ/Context/RabbitMqConsumeContext.cs
+++ b/src/L.EventBus.RabbitMQ/Context/RabbitMqConsumeContext.cs
@@ -5,7 +5,7 @@ namespace L.EventBus.RabbitMQ.Context;
 
 public class RabbitMqConsumeContext(object payload, ulong deliveryTag) : IPipeContext
 {
-    public Dictionary<string, object?> Headers { get; init; } = [];
+    public IDictionary<string, object?> Headers { get; init; } = new Dictionary<string, object?>();
     public Dictionary<string, object?> Items { get; init; } = [];
     public object Payload { get; set; } = payload;
     public ulong DeliveryTag { get; set; } = deliveryTag;

--- a/src/L.EventBus.RabbitMQ/L.EventBus.RabbitMQ.csproj
+++ b/src/L.EventBus.RabbitMQ/L.EventBus.RabbitMQ.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <Version>2.2.0</Version>
+	  <Version>2.2.1</Version>
 	  <RepositoryUrl>https://github.com/Liveron/L.EventBus</RepositoryUrl>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Fix Headers property type in RabbitMqConsumeContext from Dictionary to IDictionary for interface compatibility
- Maintain Items dictionary as Dictionary type for internal usage
- Bump version to 2.2.1 for this bug fix

This ensures proper interface compatibility while maintaining the functionality of the Items dictionary.